### PR TITLE
Require Pillow and mutagen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install pipx
+        run: |
+          python -m pip install --upgrade pip pipx
+          python -m pipx ensurepath
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
+      - name: Install llmcontext with pipx
+        run: pipx install --editable .
+      - name: Verify CLI
+        run: llmcontext --version
+      - name: Install test dependencies
+        run: python -m pip install --upgrade pip && python -m pip install -e .
+      - name: Run tests
+        run: pytest -q

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
       - name: Verify CLI
         run: llmcontext --version
       - name: Install test dependencies
-        run: python -m pip install --upgrade pip && python -m pip install -e .
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[test]
       - name: Run tests
         run: pytest -q

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
+
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
@@ -13,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Basic functionality for collecting project files
 - Respects .gitignore patterns
 - Binary file detection
+- Binary file metadata extraction for common image and audio formats using Python modules only
 - Markdown-formatted output for LLMs
 - Command-line interface with basic options
 - Detailed prompting system with --show-prompt option

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![PyPI version](https://badge.fury.io/py/llmcontext.svg)](https://badge.fury.io/py/llmcontext)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Python 3.8+](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
+[![CI](https://github.com/speakman/llmcontext/actions/workflows/ci.yml/badge.svg)](https://github.com/speakman/llmcontext/actions/workflows/ci.yml)
 
 `llmcontext` is a command-line tool that gathers all relevant files from a software project into a single text file. This text file is formatted for easy attachment to a Large Language Model (LLM) to provide it with the necessary context for analysis, refactoring, or Q&A about the project.
 
@@ -15,11 +16,11 @@ The tool intelligently excludes common non-source files, respects `.gitignore` p
   - Skips common version control, IDE, OS-specific, build artifact, and virtual environment directories/files by default.
   - Respects `.gitignore` files found in the project's root directory.
   - Allows custom exclusion patterns via command-line arguments.
-- **Binary File Handling:** Detects likely binary files and includes only their path and size, not their content.
-- **Markdown Formatting:** Source code content is wrapped in Markdown code blocks, with language hints based on file extensions.
-- **LLM-Ready Output:** The output is formatted for easy consumption by large language models.
-- **Optional Suggested Prompt:** A comprehensive LLM query can be printed to `stderr` on demand.
-- **Standard Library Only:** No external dependencies, making it easy to install and run.
+ - **Binary File Handling:** Detects likely binary files and includes metadata such as image dimensions or audio duration instead of raw content. Only Python modules are used; no external command-line tools are required.
+ - **Markdown Formatting:** Source code content is wrapped in Markdown code blocks, with language hints based on file extensions.
+ - **LLM-Ready Output:** The output is formatted for easy consumption by large language models.
+ - **Optional Suggested Prompt:** A comprehensive LLM query can be printed to `stderr` on demand.
+- **All Dependencies Included:** Uses Python libraries only and installs required packages (Pillow and mutagen) automatically.
 - **Cross-Platform:** Works on macOS, Linux, and Windows.
 
 ## Installation
@@ -162,6 +163,3 @@ Contributions are welcome! If you have suggestions for improvements or find a bu
 
 This project is licensed under the MIT License.
 
-```
-
-```

--- a/README.md
+++ b/README.md
@@ -155,6 +155,15 @@ llmcontext [ROOT_DIR] [OUTPUT_FILE] [OPTIONS]
 
 - **Target Specific Directories:** For large projects, consider running `llmcontext` on specific subdirectories rather than the entire project to focus the LLM's attention on relevant components.
 
+## Running Tests
+
+Install the optional test dependencies and run the suite with `pytest`:
+
+```bash
+python -m pip install -e .[test]
+pytest -q
+```
+
 ## Contributing
 
 Contributions are welcome! If you have suggestions for improvements or find a bug, please open an issue or submit a pull request to the [GitHub repository](https://github.com/speakman/llmcontext).

--- a/llmcontext/__init__.py
+++ b/llmcontext/__init__.py
@@ -15,6 +15,10 @@ from llmcontext.llmcontext import (
     should_exclude,
     read_gitignore_patterns,
     format_file_size,
+    get_binary_metadata,
+    extract_image_metadata,
+    extract_wav_metadata,
+    extract_audio_metadata,
     DEFAULT_EXCLUDES,
     BINARY_FILE_EXTENSIONS,
 )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
     "mutagen>=1.46",
 ]
 
+[project.optional-dependencies]
+test = ["pytest"]
+
 [project.scripts]
 llmcontext = "llmcontext:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,8 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    # Current version uses only standard library modules
-    # For future versions, these might be needed:
-    # "pathspec >= 0.11.0",
-    # "python-magic-bin; sys_platform == 'win32'", 
-    # "python-magic; sys_platform != 'win32'",
+    "Pillow>=9.0",
+    "mutagen>=1.46",
 ]
 
 [project.scripts]

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,0 +1,56 @@
+import base64
+from pathlib import Path
+import sys
+import subprocess
+import llmcontext.llmcontext as lc
+
+# Base64 encoded minimal image and audio files
+PNG_B64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAACklEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+GIF_B64 = "R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7"
+BMP_B64 = "Qk06AAAAAAAAADYAAAAoAAAAAQAAAAEAAAABABgAAAAAAAQAAADEDgAAxA4AAAAAAAAAAAAAAAAAAA=="
+JPEG_B64 = "/9j/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/yQALCAABAAEBAREA/8wABgAQEAX/2gAIAQEAAD8A0s8g/9k="
+WAV_B64 = "UklGRjQAAABXQVZFZm10IBAAAAABAAEAQB8AAIA+AAACABAAZGF0YRAAAAAAAAAAAAAAAAAAAAAAAAAA"
+
+def write_binary(path: Path, data_b64: str) -> Path:
+    data = base64.b64decode(data_b64)
+    path.write_bytes(data)
+    return path
+
+def test_extract_image_metadata(tmp_path: Path) -> None:
+    png = write_binary(tmp_path / "img.png", PNG_B64)
+    gif = write_binary(tmp_path / "img.gif", GIF_B64)
+    bmp = write_binary(tmp_path / "img.bmp", BMP_B64)
+    jpg = write_binary(tmp_path / "img.jpg", JPEG_B64)
+
+    assert lc.extract_image_metadata(png) == {"Format": "PNG", "Width": "1", "Height": "1"}
+    assert lc.extract_image_metadata(gif) == {"Format": "GIF", "Width": "1", "Height": "1"}
+    assert lc.extract_image_metadata(bmp) == {"Format": "BMP", "Width": "1", "Height": "1"}
+    assert lc.extract_image_metadata(jpg) == {"Format": "JPEG", "Width": "1", "Height": "1"}
+
+def test_extract_wav_metadata(tmp_path: Path) -> None:
+    wav = write_binary(tmp_path / "sound.wav", WAV_B64)
+    meta = lc.extract_wav_metadata(wav)
+    assert meta and meta["Format"] == "WAV"
+    assert meta["Channels"] == "1"
+    assert meta["SampleRate"] == "8000"
+
+def test_generate_context_and_cli(tmp_path: Path) -> None:
+    write_binary(tmp_path / "img.png", PNG_B64)
+    write_binary(tmp_path / "sound.wav", WAV_B64)
+    (tmp_path / "hello.txt").write_text("hello")
+
+    ctx = lc.generate_project_context(tmp_path, [], None, False)
+    assert "Format: PNG" in ctx
+    assert "Format: WAV" in ctx
+    assert "hello" in ctx
+
+    out_file = tmp_path / "out.txt"
+    proc = subprocess.run([
+        sys.executable,
+        "-m",
+        "llmcontext.llmcontext",
+        str(tmp_path),
+        str(out_file),
+    ], capture_output=True, text=True)
+    assert proc.returncode == 0
+    assert out_file.read_text().startswith("--- START PROJECT CONTEXT ---")


### PR DESCRIPTION
## Summary
- make Pillow and mutagen mandatory
- use Pillow for image metadata extraction
- clean up optional dependency logic in audio metadata
- document that dependencies are installed automatically
- add CI workflow to install with pipx and run tests

## Testing
- `pip install -e .`
- `pytest -q`
- `python -m compileall -q llmcontext`
- `python -m llmcontext.llmcontext --version`
- `python -m llmcontext.llmcontext . /tmp/out.txt --verbose --show-prompt`


------
https://chatgpt.com/codex/tasks/task_e_684957c395a4832bb66129ebc6d26bb8